### PR TITLE
Handle null values in the POLY_AREA field in ParcelOverlaysZoning.py

### DIFF
--- a/PyFiles/ParcelOverlayZoning.py
+++ b/PyFiles/ParcelOverlayZoning.py
@@ -127,7 +127,12 @@ try:
                     count += 1
                     if count in breaks:
                         print('Parsing Zoning FC ' + str(int(round(count * 100.0 / countin))) + '% complete...')
-                    if (float(row[fieldList.index('POLY_AREA')]) / float(row[fieldList.index('GROSS_AREA')])) > 0.01:  #To implment 3% coverage and thinness minimum: row[3] > 0.3 and (row[2] / float(row[1])) > 0.03:
+                    # null values in the poly_area field will break the script and they don't belong in the parcelDict anyway
+                    if row[fieldList.index('POLY_AREA')] is None:
+                        print('ParcelID ' + str(row[fieldList.index('PARCELID')]) + ' has a null POLY_AREA value.')
+                        log.info('ParcelID ' + str(row[fieldList.index('PARCELID')]) + ' has a null POLY_AREA value.')
+                        continue
+                    elif (float(row[fieldList.index('POLY_AREA')]) / float(row[fieldList.index('GROSS_AREA')])) > 0.01:  #To implment 3% coverage and thinness minimum: row[3] > 0.3 and (row[2] / float(row[1])) > 0.03:
                         if row[fieldList.index('PARCELID')] in parcelDict and row[fieldList.index('PARCELID')] is not None:
                             print('should not be here 2')
                             tempList = parcelDict[row[fieldList.index('PARCELID')]]


### PR DESCRIPTION
Write parcel info for features with null POLY_AREA values to log and continue on to the next feature in the cursor.